### PR TITLE
Fix yaml schema errors for resources description attribute.

### DIFF
--- a/part_1/template.yaml
+++ b/part_1/template.yaml
@@ -19,8 +19,8 @@ Resources:
 ##########################################################################
   webhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler
     Properties:
+      Description: A github webhook handler
       CodeUri: src/
       Handler: app.handler
       Runtime: nodejs12.x

--- a/part_2/template.yaml
+++ b/part_2/template.yaml
@@ -19,8 +19,8 @@ Resources:
 ##########################################################################
   webhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler
     Properties:
+      Description: A github webhook handler
       CodeUri: src/
       Handler: app.handler
       Runtime: nodejs12.x

--- a/part_3/template.yaml
+++ b/part_3/template.yaml
@@ -19,8 +19,8 @@ Resources:
 ##########################################################################
   StarWebhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler when repo is starred
     Properties:
+      Description: A github webhook handler when repo is starred
       CodeUri: src_starred/
       Handler: app.handler
       Runtime: nodejs12.x

--- a/part_4/template.yaml
+++ b/part_4/template.yaml
@@ -19,8 +19,8 @@ Resources:
 ##########################################################################
   StarWebhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler when repo is starred
     Properties:
+      Description: A github webhook handler when repo is starred
       CodeUri: src_starred/
       Handler: app.handler
       Runtime: nodejs12.x
@@ -42,8 +42,8 @@ Resources:
   
   PushWebhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler when repo is forked
     Properties:
+      Description: A github webhook handler when repo is forked
       CodeUri: src_push/
       Handler: app.handler
       Runtime: nodejs12.x

--- a/part_5/template.yaml
+++ b/part_5/template.yaml
@@ -19,8 +19,8 @@ Resources:
 ##########################################################################
   StarWebhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler when repo is starred
     Properties:
+      Description: A github webhook handler when repo is starred
       CodeUri: src_starred/
       Handler: app.handler
       Runtime: nodejs12.x
@@ -45,8 +45,8 @@ Resources:
   
   PushWebhookHandler:
     Type: AWS::Serverless::Function
-    Description: A github webhook handler when repo is forked
     Properties:
+      Description: A github webhook handler when repo is forked
       CodeUri: src_push/
       Handler: app.handler
       Runtime: nodejs12.x


### PR DESCRIPTION
*Description of changes:*
* Fix the template.yaml schema errors for the `AWS::Serverless::Function` yaml schema.
* All of the templates have yaml schema errors with the Resources Description property. They should be children of the `Properties` node, not the root.

For reference: [AWS::Serverless::Function Syntax](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
